### PR TITLE
COMPLETE: data_preprocessor

### DIFF
--- a/src/data_preprocessor/data_preprocessor.py
+++ b/src/data_preprocessor/data_preprocessor.py
@@ -1316,6 +1316,34 @@ class DataPreprocessor:
                 else:
                     raise ValueError(f"Unknown CREATE_TARGET kind: '{kind}'")
 
+            elif layer.action == UnifiedAction.DROP_HIGH_NULL_COLUMNS:
+                threshold = float(layer.params.get("threshold", 0.5))
+                protect = set(layer.params.get("protect") or UNIFIED_PROTECTED_COLUMNS)
+                null_frac = df.isna().mean()
+                drop_cols = [
+                    c for c in df.columns
+                    if c not in protect and null_frac[c] > threshold
+                ]
+                if drop_cols:
+                    df = df.drop(columns=drop_cols)
+                self._logger.log_info(
+                    f"DROP_HIGH_NULL_COLUMNS: dropped {len(drop_cols)} columns "
+                    f"(> {threshold:.0%} null)"
+                )
+
+            elif layer.action == UnifiedAction.DROP_CONSTANT_COLUMNS:
+                protect = set(layer.params.get("protect") or UNIFIED_PROTECTED_COLUMNS)
+                drop_cols = [
+                    c for c in df.columns
+                    if c not in protect and df[c].nunique(dropna=True) <= 1
+                ]
+                if drop_cols:
+                    df = df.drop(columns=drop_cols)
+                self._logger.log_info(
+                    f"DROP_CONSTANT_COLUMNS: dropped {len(drop_cols)} columns "
+                    f"(<= 1 distinct value)"
+                )
+
         return df
 
     def _helper_macro_wide(self, table_name: str) -> pd.DataFrame:
@@ -1393,7 +1421,8 @@ class DataPreprocessor:
         if macro_cols:
             spine[macro_cols] = spine[macro_cols].ffill()
 
-        # Datetime features, then the supervised target (future pct return).
+        # Datetime features, the supervised target (future pct return), then
+        # column cleaning (drop sparse and constant columns).
         spine = self._helper_unified_transform(
             spine,
             [
@@ -1404,6 +1433,8 @@ class DataPreprocessor:
                     kind="pct_return",
                     target_name="target",
                 ),
+                UnifiedLayer.DROP_HIGH_NULL_COLUMNS(threshold=0.5),
+                UnifiedLayer.DROP_CONSTANT_COLUMNS(),
             ],
         )
 

--- a/src/utils/enums.py
+++ b/src/utils/enums.py
@@ -376,6 +376,13 @@ class UnifiedAction(Enum):
 
     EXTRACT_DATETIME_FEATURE = "extract_datetime_feature"
     CREATE_TARGET = "create_target"
+    # Cleaning
+    DROP_HIGH_NULL_COLUMNS = "drop_high_null_columns"
+    DROP_CONSTANT_COLUMNS = "drop_constant_columns"
+
+
+# Columns never dropped by unified cleaning actions (key, identity, label).
+UNIFIED_PROTECTED_COLUMNS = ["date", "exchange", "ticker", "target"]
 
 
 class UnifiedLayer:
@@ -412,6 +419,21 @@ class UnifiedLayer:
             kind=kind,
             target_name=target_name,
         )
+
+    @classmethod
+    def DROP_HIGH_NULL_COLUMNS(cls, threshold: float = 0.5, protect: list = None):
+        """Drop columns whose null fraction is strictly greater than `threshold`
+        (0..1). `protect` columns are never dropped (default:
+        UNIFIED_PROTECTED_COLUMNS)."""
+        return cls(
+            UnifiedAction.DROP_HIGH_NULL_COLUMNS, threshold=threshold, protect=protect
+        )
+
+    @classmethod
+    def DROP_CONSTANT_COLUMNS(cls, protect: list = None):
+        """Drop columns with <= 1 distinct non-null value. `protect` columns are
+        never dropped (default: UNIFIED_PROTECTED_COLUMNS)."""
+        return cls(UnifiedAction.DROP_CONSTANT_COLUMNS, protect=protect)
 
 
 class ScrapeMainType(Enum):


### PR DESCRIPTION
Add DROP_HIGH_NULL_COLUMNS (null fraction > threshold, default 0.5) and
DROP_CONSTANT_COLUMNS (<= 1 distinct value) to UnifiedAction/UnifiedLayer, both
skipping UNIFIED_PROTECTED_COLUMNS (date/exchange/ticker/target). Wire both into
_ingest_unified_stock after CREATE_TARGET.

Per-stock cleaning drops different sparse macro series per ticker, so the 30
VN30 unified tables now range 1015-1025 cols (was 1036); rows/target unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
